### PR TITLE
MPU Task Creation Check Region Settings

### DIFF
--- a/portable/GCC/ARM_CRx_MPU/port.c
+++ b/portable/GCC/ARM_CRx_MPU/port.c
@@ -149,10 +149,8 @@ PRIVILEGED_FUNCTION void vPortExitCritical( void );
 /**
  * @brief Determine if the MPU Register Settings are valid MPU Settings
  */
-BaseType_t xPortMPURegisterCheck(
-    xMPU_REGION_REGISTERS * xMPURegisters,
-    uint32_t ulTaskFlags
-)
+BaseType_t xPortMPURegisterCheck( xMPU_REGION_REGISTERS * xMPURegisters,
+                                  uint32_t ulTaskFlags )
 {
 #if defined( __ARMCC_VERSION )
     /* Declaration when these variable are defined in code instead of being
@@ -668,6 +666,15 @@ static void prvSetupMPU( void )
                    ( uint32_t ) __FLASH_segment_start__,
                    ( ulRegionLengthEncoded | portMPU_REGION_ENABLE ),
                    ( portMPU_REGION_PRIV_RO_USER_RO_EXEC |
+                     portMPU_REGION_NORMAL_OIWTNOWA_SHARED ) );
+
+    /* Priv: RX, Unpriv: No access for privileged functions. */
+    ulRegionLength = ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__;
+    ulRegionLengthEncoded = prvGetMPURegionSizeEncoding( ulRegionLength );
+    vMPUSetRegion( portPRIVILEGED_FLASH_REGION,
+                   ( uint32_t ) __privileged_functions_start__,
+                   ( ulRegionLengthEncoded | portMPU_REGION_ENABLE ),
+                   ( portMPU_REGION_PRIV_RO_USER_NA_EXEC |
                      portMPU_REGION_NORMAL_OIWTNOWA_SHARED ) );
 
     /* Enable the MPU background region - it allows privileged operating modes

--- a/portable/GCC/ARM_CRx_MPU/portmacro_asm.h
+++ b/portable/GCC/ARM_CRx_MPU/portmacro_asm.h
@@ -124,11 +124,9 @@ extern "C" {
 
 /* Default MPU regions. */
 #define portFIRST_CONFIGURABLE_REGION ( 0 )
-#define portLAST_CONFIGURABLE_REGION  ( portMPU_TOTAL_REGIONS - 5UL )
-#define portSTACK_REGION              ( portMPU_TOTAL_REGIONS - 4UL )
-#define portUNPRIVILEGED_FLASH_REGION ( portMPU_TOTAL_REGIONS - 3UL )
-#define portPRIVILEGED_FLASH_REGION   ( portMPU_TOTAL_REGIONS - 2UL )
-#define portPRIVILEGED_RAM_REGION     ( portMPU_TOTAL_REGIONS - 1UL )
+#define portLAST_CONFIGURABLE_REGION  ( portMPU_TOTAL_REGIONS - 3UL )
+#define portSTACK_REGION              ( portMPU_TOTAL_REGIONS - 2UL )
+#define portUNPRIVILEGED_FLASH_REGION ( portMPU_TOTAL_REGIONS - 1UL )
 #define portNUM_CONFIGURABLE_REGIONS \
     ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1UL )
 /* Plus one to make space for the stack region. */

--- a/portable/GCC/ARM_CRx_MPU/portmacro_asm.h
+++ b/portable/GCC/ARM_CRx_MPU/portmacro_asm.h
@@ -124,9 +124,10 @@ extern "C" {
 
 /* Default MPU regions. */
 #define portFIRST_CONFIGURABLE_REGION ( 0 )
-#define portLAST_CONFIGURABLE_REGION  ( portMPU_TOTAL_REGIONS - 3UL )
-#define portSTACK_REGION              ( portMPU_TOTAL_REGIONS - 2UL )
-#define portUNPRIVILEGED_FLASH_REGION ( portMPU_TOTAL_REGIONS - 1UL )
+#define portLAST_CONFIGURABLE_REGION  ( portMPU_TOTAL_REGIONS - 4UL )
+#define portSTACK_REGION              ( portMPU_TOTAL_REGIONS - 3UL )
+#define portUNPRIVILEGED_FLASH_REGION ( portMPU_TOTAL_REGIONS - 2UL )
+#define portPRIVILEGED_FLASH_REGION   ( portMPU_TOTAL_REGIONS - 1UL )
 #define portNUM_CONFIGURABLE_REGIONS \
     ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1UL )
 /* Plus one to make space for the stack region. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This is a POC of how to remove the PRIVILEGED_DATA and PRIVILEGED_FUNCTIONS MPU Regions from the FreeRTOS-Kernel. This is done by inspecting the MPU settings a task is attempting to be created with to determine if it is:
1. Trying to grant itself write permissions to FLASH
1. Trying to grant itself execute permissions to RAM
1. Trying to grant itself read/write to [PRIVILEGED_FLASH/PRIVILEGED_DATA](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/include/mpu_wrappers.h#L270) when being created as an unprivileged task

There are additional checks for invalid MPU settings as well, to assist end-users when creating MPU enabled tasks.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Modify a task's MPU settings to attempt to grant write permissions to FLASH
1. Modify a task's MPU settings to attempt to grant execute permissions to RAM
1. Modify an unprivileged task's MPU Settings to attempt to grant permissions to [PRIVILEGED_FLASH/PRIVILEGED_DATA](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/include/mpu_wrappers.h#L270)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
